### PR TITLE
change awx_teams variable for automation of teams in awx

### DIFF
--- a/configure.yml
+++ b/configure.yml
@@ -202,13 +202,13 @@
 
         - name: manage awx teams
           tower_team:
-            name: "{{ team.name }}"
-            organization: "{{ team.organization }}"
-            state: "{{ team.state | default('present') }}"
+            name: "{{ team.key }}"
+            organization: "{{ team.value.organization }}"
+            state: "{{ team.value.state | default('present') }}"
           loop_control:
             loop_var: team
-            label: "{{ team.name }}"
-          loop: "{{ awx_teams | default([]) }}"
+            label: "{{ team }}"
+          loop: "{{ lookup('dict', awx_teams) }}"
           tags:
             - teams
 


### PR DESCRIPTION
Example awx_teams vars:
awx_teams:
  "{{ awx_users_team_name }}":
    organization: example.io
    users: 'cn=AWX Users,ou=Security Groups,{{ awx_ldap_domain_dn }}'
    remove: true
  "{{ awx_web_team_name }}" :
    organization: example.io
    users: 'cn=AWX Web Users,ou=Security Groups,{{ awx_ldap_domain_dn }}'
    remove: true